### PR TITLE
Update HtmlSanitizer and remove IIS Express settings

### DIFF
--- a/AspNetCoreUploadTest.csproj
+++ b/AspNetCoreUploadTest.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlSanitizer" Version="8.1.870" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
   </ItemGroup>
 
 </Project>

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,23 +1,8 @@
 ﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:21179",
-      "sslPort": 44396
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "AspNetCoreUploadTest": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {


### PR DESCRIPTION
Upgraded HtmlSanitizer package in `AspNetCoreUploadTest.csproj` from version 8.1.870 to 9.0.886. Removed IIS Express-related settings and profiles from `launchSettings.json`, indicating a shift away from IIS Express for development. Updated `dotnetRunMessages` in `launchSettings.json` to use a boolean value instead of a string for proper data type consistency.